### PR TITLE
Makes shinyjs a suggested dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,10 +20,10 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 Imports: httr,
     shiny,
-    shinyjs,
     yaml,
     utils
 Suggests: 
     knitr,
-    rmarkdown
+    rmarkdown,
+    shinyjs
 VignetteBuilder: knitr

--- a/R/logout.R
+++ b/R/logout.R
@@ -71,6 +71,11 @@ logout_url <- function() {
 #'
 #' @export
 logout <- function() {
+
+  if (!requireNamespace("shinyjs", quietly = TRUE)) {
+    stop("Package \"shinyjs\" required.", call. = FALSE)
+  }
+
   shiny::insertUI(
     selector = "head", where = "beforeEnd", immediate = TRUE,
     ui = shinyjs::useShinyjs()


### PR DESCRIPTION
As noted in #48, `shinyjs` isn't that necessary (only if you want the logout button). We can't remove `shiny` from imports because that is what the package is for, but the rest is mostly optional.