### PR TITLE
replace GET() with RETRY()

### DIFF
--- a/R/auth0.R
+++ b/R/auth0.R
@@ -25,7 +25,12 @@ auth0_server_verify <- function(session, app, api, state) {
       user_params = list(grant_type = "authorization_code"))
 
     userinfo_url <- sub("authorize", "userinfo", api$authorize)
-    resp <- httr::GET(userinfo_url, httr::config(token = token))
+    resp <- httr::RETRY(
+      verb = "GET"
+      , url = userinfo_url
+      , httr::config(token = token)
+      , times = 5
+    )
 
     assign("auth0_credentials", token$credentials, envir = session$userData)
     assign("auth0_info", httr::content(resp, "parsed"), envir = session$userData)


### PR DESCRIPTION
Thanks for for this awesome project!

In this PR, I'd like to propose swapping out calls to `httr::GET()` etc. with `httr::RETRY()`. This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on https://github.com/chircollab/chircollab20/issues/1 as part of Chicago R Collab, an R 'unconference' in Chicago.